### PR TITLE
bumpy to jupyter-book 0.11.3, change TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository is configured with [GitHub Actions](./.github/workflows/deploy.y
 ```
 git clone https://github.com/uwhackweek/hackweeks-as-a-service.git
 cd hackweeks-as-a-service
-conda env create -f environment.yml
+conda env create
 conda activate hackweek
 jb build docs
 ```

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,7 +1,7 @@
 # Book settings
 # Learn more at https://jupyterbook.org/customize/config.html
 
-title: University of Washington eScience Institute
+title: ""
 author: eScience Institute, University of Washington
 logo: logo.png
 
@@ -31,6 +31,7 @@ sphinx:
 # Add GitHub buttons to your book
 # See https://jupyterbook.org/customize/config.html#add-a-link-to-your-repository
 html:
+  home_page_in_navbar: false
   use_edit_page_button: true
   use_issues_button: true
   use_repository_button: true

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -1,29 +1,27 @@
-# Table of content
-# Learn more at https://jupyterbook.org/customize/toc.html
-#
-- file: intro
-- part: Overview
-  chapters: 
+format: jb-book
+root: intro
+parts:
+- caption: Overview
+  chapters:
   - file: mission
   - file: team
-- part: Hackweek Services
+- caption: Hackweek Services
   chapters:
   - file: client
   - file: services
   - file: application
-- part: Resources for Organizers
+- caption: Resources for Organizers
   chapters:
   - file: tutorials
   - file: teaching-resources
-#  - file: selection # needs work
-- part: Gallery
-  chapters: 
-    - file: gallery/index
-      sections:
-      - file: gallery/ICESat-2hackweek
-      - file: gallery/SnowExhackweek
-      - file: gallery/geohackweek
-- part: Reference
-  chapters:  
+- caption: Gallery
+  chapters:
+  - file: gallery/index
+    sections:
+    - file: gallery/ICESat-2hackweek
+    - file: gallery/SnowExhackweek
+    - file: gallery/geohackweek
+- caption: Reference
+  chapters:
   - file: bibliography
   - file: acknowledgements

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,4 @@ channels:
   - conda-forge
 dependencies:
   - python=3.8
-  - jupyter-book=0.10.2
-  - pip=20
-  - pip:
-    - sphinxcontrib-bibtex==2.2.0
+  - jupyter-book=0.11.3


### PR DESCRIPTION
followed this guide to convert table of contents structure https://jupyterbook.org/customize/toc.html 

Also want to test the netlify workflow which was missing a `synchronize` key to update the preview with every new commit to an open PR.
https://github.com/uwhackweek/hackweeks-as-a-service/blob/3a090a507328c7a201db7a692dff271d432ce340/.github/workflows/netlifypreview.yaml#L5
