### PR TITLE
first try at listing OT training schedule

### DIFF
--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -76,7 +76,7 @@ Upon completion of this training you will be awarded a tutorial lead badge! ![GH
 
 ## Project Coordinator
 
-# Helper
+## Helper
 
 
 ## Funding Support    

--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -21,7 +21,7 @@ The eScience Institute supports Community Partners in planning each hackweek. We
 
 ## Tutorial Lead Meeting Schedule
 
-Tutorial leads and developers will gather two months prior to a hackweek to create content and prepare for teaching. Here is the weekly schedule:
+Tutorial leads and developers typically gather over the course of eight to ten weeks prior to a hackweek to create content and prepare for teaching. Below is an example eight week meeting schedule, which does not include individual or team time spent preparing tutorial content:
 
 ```{Admonition} Week 1 / 90 min: Kick-off Meeting (everyone)
 Create tutorial schedule outline, form tutorial teams, and get to know each other.

--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -5,16 +5,16 @@ The eScience Institute supports Community Partners in planning each hackweek. We
 ::::{grid}
 :gutter: 1
 
-:::{grid-item-card} [Tutorial Developer](#tutorial-developer)
-[![GH](https://img.shields.io/static/v1?label=Hackweek&message=Tutorial_Developer&color=4b2e83&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAAOCAQAAABedl5ZAAAACXBIWXMAAAHKAAABygHMtnUxAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAMNJREFUGBltwcEqwwEcAOAfc1F2sNsOTqSlNUopSv5jW1YzHHYY/6YtLa1Jy4mbl3Bz8QIeyKM4fMaUxr4vZnEpjWnmLMSYCysxTcddhF25+EvJia5hhCudULAePyRalvUteXIfBgYxJufRuaKuprKsbDjVUrUj40FNQ11PTzEmrCmrevPhRcVQai8m1PRVvOPZgX2JttWYsGhD3atbHWcyUqX4oqDtJkJiJHUYv+R1JbaNHJmP/+Q1HLu2GbNoSm3Ft0+Y1YMdPSTSwQAAAABJRU5ErkJggg==&style=plastic)](#tutorial-developer)
+:::{grid-item-card} [Tutorial Developer](#tutorial-developer-schedule)
+[![GH](https://img.shields.io/static/v1?label=Hackweek&message=Tutorial_Developer&color=4b2e83&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAAOCAQAAABedl5ZAAAACXBIWXMAAAHKAAABygHMtnUxAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAMNJREFUGBltwcEqwwEcAOAfc1F2sNsOTqSlNUopSv5jW1YzHHYY/6YtLa1Jy4mbl3Bz8QIeyKM4fMaUxr4vZnEpjWnmLMSYCysxTcddhF25+EvJia5hhCudULAePyRalvUteXIfBgYxJufRuaKuprKsbDjVUrUj40FNQ11PTzEmrCmrevPhRcVQai8m1PRVvOPZgX2JttWYsGhD3atbHWcyUqX4oqDtJkJiJHUYv+R1JbaNHJmP/+Q1HLu2GbNoSm3Ft0+Y1YMdPSTSwQAAAABJRU5ErkJggg==&style=plastic)](#tutorial-developer-schedule)
 :::
 
-:::{grid-item-card} [Project Consultant](#project-consultant)
-[![GH](https://img.shields.io/static/v1?label=Hackweek&message=Project_Consultant&color=4b2e83&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAAOCAQAAABedl5ZAAAACXBIWXMAAAHKAAABygHMtnUxAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAMNJREFUGBltwcEqwwEcAOAfc1F2sNsOTqSlNUopSv5jW1YzHHYY/6YtLa1Jy4mbl3Bz8QIeyKM4fMaUxr4vZnEpjWnmLMSYCysxTcddhF25+EvJia5hhCudULAePyRalvUteXIfBgYxJufRuaKuprKsbDjVUrUj40FNQ11PTzEmrCmrevPhRcVQai8m1PRVvOPZgX2JttWYsGhD3atbHWcyUqX4oqDtJkJiJHUYv+R1JbaNHJmP/+Q1HLu2GbNoSm3Ft0+Y1YMdPSTSwQAAAABJRU5ErkJggg==&style=plastic)](#project-consultant)
+:::{grid-item-card} [Project Consultant](#project-consultant-schedule)
+[![GH](https://img.shields.io/static/v1?label=Hackweek&message=Project_Consultant&color=4b2e83&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAAOCAQAAABedl5ZAAAACXBIWXMAAAHKAAABygHMtnUxAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAMNJREFUGBltwcEqwwEcAOAfc1F2sNsOTqSlNUopSv5jW1YzHHYY/6YtLa1Jy4mbl3Bz8QIeyKM4fMaUxr4vZnEpjWnmLMSYCysxTcddhF25+EvJia5hhCudULAePyRalvUteXIfBgYxJufRuaKuprKsbDjVUrUj40FNQ11PTzEmrCmrevPhRcVQai8m1PRVvOPZgX2JttWYsGhD3atbHWcyUqX4oqDtJkJiJHUYv+R1JbaNHJmP/+Q1HLu2GbNoSm3Ft0+Y1YMdPSTSwQAAAABJRU5ErkJggg==&style=plastic)](#project-consultant-schedule)
 :::
 
-:::{grid-item-card} [Helper](#helper)
-[![GH](https://img.shields.io/static/v1?label=Hackweek&message=Helper&color=4b2e83&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAAOCAQAAABedl5ZAAAACXBIWXMAAAHKAAABygHMtnUxAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAMNJREFUGBltwcEqwwEcAOAfc1F2sNsOTqSlNUopSv5jW1YzHHYY/6YtLa1Jy4mbl3Bz8QIeyKM4fMaUxr4vZnEpjWnmLMSYCysxTcddhF25+EvJia5hhCudULAePyRalvUteXIfBgYxJufRuaKuprKsbDjVUrUj40FNQ11PTzEmrCmrevPhRcVQai8m1PRVvOPZgX2JttWYsGhD3atbHWcyUqX4oqDtJkJiJHUYv+R1JbaNHJmP/+Q1HLu2GbNoSm3Ft0+Y1YMdPSTSwQAAAABJRU5ErkJggg==&style=plastic)](#helper)
+:::{grid-item-card} [Helper](#helper-schedule)
+[![GH](https://img.shields.io/static/v1?label=Hackweek&message=Helper&color=4b2e83&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAAOCAQAAABedl5ZAAAACXBIWXMAAAHKAAABygHMtnUxAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAMNJREFUGBltwcEqwwEcAOAfc1F2sNsOTqSlNUopSv5jW1YzHHYY/6YtLa1Jy4mbl3Bz8QIeyKM4fMaUxr4vZnEpjWnmLMSYCysxTcddhF25+EvJia5hhCudULAePyRalvUteXIfBgYxJufRuaKuprKsbDjVUrUj40FNQ11PTzEmrCmrevPhRcVQai8m1PRVvOPZgX2JttWYsGhD3atbHWcyUqX4oqDtJkJiJHUYv+R1JbaNHJmP/+Q1HLu2GbNoSm3Ft0+Y1YMdPSTSwQAAAABJRU5ErkJggg==&style=plastic)](#helper-schedule)
 :::
 
 ::::

--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -5,12 +5,12 @@ The eScience Institute supports Community Partners in planning each hackweek. We
 ::::{grid}
 :gutter: 1
 
-:::{grid-item-card} [Tutorial Lead](#tutorial-lead)
-[![GH](https://img.shields.io/static/v1?label=Hackweek&message=Tutorial_Lead&color=4b2e83&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAAOCAQAAABedl5ZAAAACXBIWXMAAAHKAAABygHMtnUxAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAMNJREFUGBltwcEqwwEcAOAfc1F2sNsOTqSlNUopSv5jW1YzHHYY/6YtLa1Jy4mbl3Bz8QIeyKM4fMaUxr4vZnEpjWnmLMSYCysxTcddhF25+EvJia5hhCudULAePyRalvUteXIfBgYxJufRuaKuprKsbDjVUrUj40FNQ11PTzEmrCmrevPhRcVQai8m1PRVvOPZgX2JttWYsGhD3atbHWcyUqX4oqDtJkJiJHUYv+R1JbaNHJmP/+Q1HLu2GbNoSm3Ft0+Y1YMdPSTSwQAAAABJRU5ErkJggg==&style=plastic)](#tutorial-lead)
+:::{grid-item-card} [Tutorial Developer](#tutorial-developer)
+[![GH](https://img.shields.io/static/v1?label=Hackweek&message=Tutorial_Developer&color=4b2e83&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAAOCAQAAABedl5ZAAAACXBIWXMAAAHKAAABygHMtnUxAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAMNJREFUGBltwcEqwwEcAOAfc1F2sNsOTqSlNUopSv5jW1YzHHYY/6YtLa1Jy4mbl3Bz8QIeyKM4fMaUxr4vZnEpjWnmLMSYCysxTcddhF25+EvJia5hhCudULAePyRalvUteXIfBgYxJufRuaKuprKsbDjVUrUj40FNQ11PTzEmrCmrevPhRcVQai8m1PRVvOPZgX2JttWYsGhD3atbHWcyUqX4oqDtJkJiJHUYv+R1JbaNHJmP/+Q1HLu2GbNoSm3Ft0+Y1YMdPSTSwQAAAABJRU5ErkJggg==&style=plastic)](#tutorial-developer)
 :::
 
 :::{grid-item-card} [Project Consultant](#project-consultant)
-[![GH](https://img.shields.io/static/v1?label=Hackweek&message=Project_Coordinator&color=4b2e83&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAAOCAQAAABedl5ZAAAACXBIWXMAAAHKAAABygHMtnUxAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAMNJREFUGBltwcEqwwEcAOAfc1F2sNsOTqSlNUopSv5jW1YzHHYY/6YtLa1Jy4mbl3Bz8QIeyKM4fMaUxr4vZnEpjWnmLMSYCysxTcddhF25+EvJia5hhCudULAePyRalvUteXIfBgYxJufRuaKuprKsbDjVUrUj40FNQ11PTzEmrCmrevPhRcVQai8m1PRVvOPZgX2JttWYsGhD3atbHWcyUqX4oqDtJkJiJHUYv+R1JbaNHJmP/+Q1HLu2GbNoSm3Ft0+Y1YMdPSTSwQAAAABJRU5ErkJggg==&style=plastic)](#project-consultant)
+[![GH](https://img.shields.io/static/v1?label=Hackweek&message=Project_Consultant&color=4b2e83&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAAOCAQAAABedl5ZAAAACXBIWXMAAAHKAAABygHMtnUxAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAMNJREFUGBltwcEqwwEcAOAfc1F2sNsOTqSlNUopSv5jW1YzHHYY/6YtLa1Jy4mbl3Bz8QIeyKM4fMaUxr4vZnEpjWnmLMSYCysxTcddhF25+EvJia5hhCudULAePyRalvUteXIfBgYxJufRuaKuprKsbDjVUrUj40FNQ11PTzEmrCmrevPhRcVQai8m1PRVvOPZgX2JttWYsGhD3atbHWcyUqX4oqDtJkJiJHUYv+R1JbaNHJmP/+Q1HLu2GbNoSm3Ft0+Y1YMdPSTSwQAAAABJRU5ErkJggg==&style=plastic)](#project-consultant)
 :::
 
 :::{grid-item-card} [Helper](#helper)
@@ -23,9 +23,11 @@ The eScience Institute supports Community Partners in planning each hackweek. We
 
 ## Tutorial Developer Schedule
 
-![GH](https://img.shields.io/static/v1?label=Hackweek&message=Tutorial_Lead&color=4b2e83&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAAOCAQAAABedl5ZAAAACXBIWXMAAAHKAAABygHMtnUxAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAMNJREFUGBltwcEqwwEcAOAfc1F2sNsOTqSlNUopSv5jW1YzHHYY/6YtLa1Jy4mbl3Bz8QIeyKM4fMaUxr4vZnEpjWnmLMSYCysxTcddhF25+EvJia5hhCudULAePyRalvUteXIfBgYxJufRuaKuprKsbDjVUrUj40FNQ11PTzEmrCmrevPhRcVQai8m1PRVvOPZgX2JttWYsGhD3atbHWcyUqX4oqDtJkJiJHUYv+R1JbaNHJmP/+Q1HLu2GbNoSm3Ft0+Y1YMdPSTSwQAAAABJRU5ErkJggg==&style=plastic)
+![GH](https://img.shields.io/static/v1?label=Hackweek&message=Tutorial_Developer&color=4b2e83&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAAOCAQAAABedl5ZAAAACXBIWXMAAAHKAAABygHMtnUxAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAMNJREFUGBltwcEqwwEcAOAfc1F2sNsOTqSlNUopSv5jW1YzHHYY/6YtLa1Jy4mbl3Bz8QIeyKM4fMaUxr4vZnEpjWnmLMSYCysxTcddhF25+EvJia5hhCudULAePyRalvUteXIfBgYxJufRuaKuprKsbDjVUrUj40FNQ11PTzEmrCmrevPhRcVQai8m1PRVvOPZgX2JttWYsGhD3atbHWcyUqX4oqDtJkJiJHUYv+R1JbaNHJmP/+Q1HLu2GbNoSm3Ft0+Y1YMdPSTSwQAAAABJRU5ErkJggg==&style=plastic)
 
-Tutorial leads and developers typically gather over the course of about eight weeks prior to a hackweek to create content and prepare for teaching. Below is an example eight week meeting schedule, which does not include individual or team time spent preparing tutorial content:
+Tutorial developers typically gather over the course of about eight weeks prior to a hackweek to create content and prepare for teaching. One or more of the developers will also take on the role of delivering the tutorial during the hackweek.
+
+Below is an example eight week meeting schedule, which does not include individual or team time spent preparing tutorial content:
 
 ```{Admonition} Week -8 (90 min): Kick-off Meeting (everyone)
 Create tutorial schedule outline, form tutorial teams, and get to know each other.
@@ -74,14 +76,14 @@ Coordination, logistics, and final preparations.
 ```
 
 ```{Admonition} Hackweek
-One or more of the tutorial developers delivers the content on the specified day. Other developer(s) attend to offer help.
+One or more of the tutorial developers delivers the content on the specified day, earning a ![GH](https://img.shields.io/static/v1?label=Hackweek&message=Tutorial_Teacher&color=4b2e83&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAAOCAQAAABedl5ZAAAACXBIWXMAAAHKAAABygHMtnUxAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAMNJREFUGBltwcEqwwEcAOAfc1F2sNsOTqSlNUopSv5jW1YzHHYY/6YtLa1Jy4mbl3Bz8QIeyKM4fMaUxr4vZnEpjWnmLMSYCysxTcddhF25+EvJia5hhCudULAePyRalvUteXIfBgYxJufRuaKuprKsbDjVUrUj40FNQ11PTzEmrCmrevPhRcVQai8m1PRVvOPZgX2JttWYsGhD3atbHWcyUqX4oqDtJkJiJHUYv+R1JbaNHJmP/+Q1HLu2GbNoSm3Ft0+Y1YMdPSTSwQAAAABJRU5ErkJggg==&style=plastic). Other developer(s) usually attend to offer additional help.
 ```
 
 <hr>
 
 ## Project Consultant Schedule
 
-![GH](https://img.shields.io/static/v1?label=Hackweek&message=Project_Coordinator&color=4b2e83&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAAOCAQAAABedl5ZAAAACXBIWXMAAAHKAAABygHMtnUxAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAMNJREFUGBltwcEqwwEcAOAfc1F2sNsOTqSlNUopSv5jW1YzHHYY/6YtLa1Jy4mbl3Bz8QIeyKM4fMaUxr4vZnEpjWnmLMSYCysxTcddhF25+EvJia5hhCudULAePyRalvUteXIfBgYxJufRuaKuprKsbDjVUrUj40FNQ11PTzEmrCmrevPhRcVQai8m1PRVvOPZgX2JttWYsGhD3atbHWcyUqX4oqDtJkJiJHUYv+R1JbaNHJmP/+Q1HLu2GbNoSm3Ft0+Y1YMdPSTSwQAAAABJRU5ErkJggg==&style=plastic)
+![GH](https://img.shields.io/static/v1?label=Hackweek&message=Project_Consultant&color=4b2e83&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAAOCAQAAABedl5ZAAAACXBIWXMAAAHKAAABygHMtnUxAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAMNJREFUGBltwcEqwwEcAOAfc1F2sNsOTqSlNUopSv5jW1YzHHYY/6YtLa1Jy4mbl3Bz8QIeyKM4fMaUxr4vZnEpjWnmLMSYCysxTcddhF25+EvJia5hhCudULAePyRalvUteXIfBgYxJufRuaKuprKsbDjVUrUj40FNQ11PTzEmrCmrevPhRcVQai8m1PRVvOPZgX2JttWYsGhD3atbHWcyUqX4oqDtJkJiJHUYv+R1JbaNHJmP/+Q1HLu2GbNoSm3Ft0+Y1YMdPSTSwQAAAABJRU5ErkJggg==&style=plastic)
 
 The [Project Consultant](../services/project-consultant.md) has a big-picture view of the possible scope of projects for the hackweek community, and helps participants get clear on project ideas and objectives. Project Consultants are asked to participate in a virtual training session, and to begin assisting participants in advance of the event:
 

--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -6,15 +6,15 @@ The eScience Institute supports Community Partners in planning each hackweek. We
 :gutter: 1
 
 :::{grid-item-card} [Tutorial Lead](#tutorial-lead)
-[![GH](https://img.shields.io/static/v1?label=eScience&message=Tutorial-Lead&color=b7a57a)](#tutorial-lead)
+[![GH](https://img.shields.io/static/v1?label=Hackweek&message=Tutorial_Lead&color=4b2e83&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAAOCAQAAABedl5ZAAAACXBIWXMAAAHKAAABygHMtnUxAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAMNJREFUGBltwcEqwwEcAOAfc1F2sNsOTqSlNUopSv5jW1YzHHYY/6YtLa1Jy4mbl3Bz8QIeyKM4fMaUxr4vZnEpjWnmLMSYCysxTcddhF25+EvJia5hhCudULAePyRalvUteXIfBgYxJufRuaKuprKsbDjVUrUj40FNQ11PTzEmrCmrevPhRcVQai8m1PRVvOPZgX2JttWYsGhD3atbHWcyUqX4oqDtJkJiJHUYv+R1JbaNHJmP/+Q1HLu2GbNoSm3Ft0+Y1YMdPSTSwQAAAABJRU5ErkJggg==&style=plastic)](#tutorial-lead)
 :::
 
 :::{grid-item-card} [Project Coordinator](#project-coordinator)
-[![GH](https://img.shields.io/static/v1?label=eScience&message=Project-Coordinator&color=85754d)](#project-coordinator)
+[![GH](https://img.shields.io/static/v1?label=Hackweek&message=Project_Coordinator&color=4b2e83&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAAOCAQAAABedl5ZAAAACXBIWXMAAAHKAAABygHMtnUxAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAMNJREFUGBltwcEqwwEcAOAfc1F2sNsOTqSlNUopSv5jW1YzHHYY/6YtLa1Jy4mbl3Bz8QIeyKM4fMaUxr4vZnEpjWnmLMSYCysxTcddhF25+EvJia5hhCudULAePyRalvUteXIfBgYxJufRuaKuprKsbDjVUrUj40FNQ11PTzEmrCmrevPhRcVQai8m1PRVvOPZgX2JttWYsGhD3atbHWcyUqX4oqDtJkJiJHUYv+R1JbaNHJmP/+Q1HLu2GbNoSm3Ft0+Y1YMdPSTSwQAAAABJRU5ErkJggg==&style=plastic)](#project-coordinator)
 :::
 
 :::{grid-item-card} [Helper](#helper)
-[![GH](https://img.shields.io/static/v1?label=eScience&message=Helper&color=4b2e83)](#helper)
+[![GH](https://img.shields.io/static/v1?label=Hackweek&message=Helper&color=4b2e83&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAAOCAQAAABedl5ZAAAACXBIWXMAAAHKAAABygHMtnUxAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAMNJREFUGBltwcEqwwEcAOAfc1F2sNsOTqSlNUopSv5jW1YzHHYY/6YtLa1Jy4mbl3Bz8QIeyKM4fMaUxr4vZnEpjWnmLMSYCysxTcddhF25+EvJia5hhCudULAePyRalvUteXIfBgYxJufRuaKuprKsbDjVUrUj40FNQ11PTzEmrCmrevPhRcVQai8m1PRVvOPZgX2JttWYsGhD3atbHWcyUqX4oqDtJkJiJHUYv+R1JbaNHJmP/+Q1HLu2GbNoSm3Ft0+Y1YMdPSTSwQAAAABJRU5ErkJggg==&style=plastic)](#helper)
 :::
 
 ::::
@@ -69,7 +69,7 @@ Practice tutorial delivery and get constructive feedback from others on the team
 Coordination, logistics, and final preparations.
 ```
 
-Upon completion of this training you will be awarded a tutorial lead badge! ![GH](https://img.shields.io/static/v1?label=eScience&message=Tutorial-Lead&color=b7a57a).
+Upon completion of this training you will be awarded a tutorial lead badge! ![GH](https://img.shields.io/static/v1?label=Hackweek&message=Tutorial_Lead&color=4b2e83&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAAOCAQAAABedl5ZAAAACXBIWXMAAAHKAAABygHMtnUxAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAMNJREFUGBltwcEqwwEcAOAfc1F2sNsOTqSlNUopSv5jW1YzHHYY/6YtLa1Jy4mbl3Bz8QIeyKM4fMaUxr4vZnEpjWnmLMSYCysxTcddhF25+EvJia5hhCudULAePyRalvUteXIfBgYxJufRuaKuprKsbDjVUrUj40FNQ11PTzEmrCmrevPhRcVQai8m1PRVvOPZgX2JttWYsGhD3atbHWcyUqX4oqDtJkJiJHUYv+R1JbaNHJmP/+Q1HLu2GbNoSm3Ft0+Y1YMdPSTSwQAAAABJRU5ErkJggg==&style=plastic).
 
 
 

--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -9,8 +9,8 @@ The eScience Institute supports Community Partners in planning each hackweek. We
 [![GH](https://img.shields.io/static/v1?label=Hackweek&message=Tutorial_Lead&color=4b2e83&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAAOCAQAAABedl5ZAAAACXBIWXMAAAHKAAABygHMtnUxAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAMNJREFUGBltwcEqwwEcAOAfc1F2sNsOTqSlNUopSv5jW1YzHHYY/6YtLa1Jy4mbl3Bz8QIeyKM4fMaUxr4vZnEpjWnmLMSYCysxTcddhF25+EvJia5hhCudULAePyRalvUteXIfBgYxJufRuaKuprKsbDjVUrUj40FNQ11PTzEmrCmrevPhRcVQai8m1PRVvOPZgX2JttWYsGhD3atbHWcyUqX4oqDtJkJiJHUYv+R1JbaNHJmP/+Q1HLu2GbNoSm3Ft0+Y1YMdPSTSwQAAAABJRU5ErkJggg==&style=plastic)](#tutorial-lead)
 :::
 
-:::{grid-item-card} [Project Coordinator](#project-coordinator)
-[![GH](https://img.shields.io/static/v1?label=Hackweek&message=Project_Coordinator&color=4b2e83&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAAOCAQAAABedl5ZAAAACXBIWXMAAAHKAAABygHMtnUxAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAMNJREFUGBltwcEqwwEcAOAfc1F2sNsOTqSlNUopSv5jW1YzHHYY/6YtLa1Jy4mbl3Bz8QIeyKM4fMaUxr4vZnEpjWnmLMSYCysxTcddhF25+EvJia5hhCudULAePyRalvUteXIfBgYxJufRuaKuprKsbDjVUrUj40FNQ11PTzEmrCmrevPhRcVQai8m1PRVvOPZgX2JttWYsGhD3atbHWcyUqX4oqDtJkJiJHUYv+R1JbaNHJmP/+Q1HLu2GbNoSm3Ft0+Y1YMdPSTSwQAAAABJRU5ErkJggg==&style=plastic)](#project-coordinator)
+:::{grid-item-card} [Project Consultant](#project-consultant)
+[![GH](https://img.shields.io/static/v1?label=Hackweek&message=Project_Coordinator&color=4b2e83&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAAOCAQAAABedl5ZAAAACXBIWXMAAAHKAAABygHMtnUxAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAMNJREFUGBltwcEqwwEcAOAfc1F2sNsOTqSlNUopSv5jW1YzHHYY/6YtLa1Jy4mbl3Bz8QIeyKM4fMaUxr4vZnEpjWnmLMSYCysxTcddhF25+EvJia5hhCudULAePyRalvUteXIfBgYxJufRuaKuprKsbDjVUrUj40FNQ11PTzEmrCmrevPhRcVQai8m1PRVvOPZgX2JttWYsGhD3atbHWcyUqX4oqDtJkJiJHUYv+R1JbaNHJmP/+Q1HLu2GbNoSm3Ft0+Y1YMdPSTSwQAAAABJRU5ErkJggg==&style=plastic)](#project-consultant)
 :::
 
 :::{grid-item-card} [Helper](#helper)
@@ -75,7 +75,19 @@ Upon completion of this training you will be awarded a tutorial lead badge! ![GH
 
 <hr>
 
-## Project Coordinator
+## Project Consultant
+
+The [Project Consultant](../services/project-consultant.md) has a big-picture view of the possible scope of projects for the hackweek community, and helps participants get clear on project ideas and objectives. Project Consultants are asked to participate in a virtual training session, and to begin assisting participants in advance of the event:
+
+```{Admonition} 60 min: Project Consultant Orientation
+Learn our approach for setting up and guiding project work; discuss approaches for fostering project ideas for this specific community.
+```
+
+```{Admonition} Guiding Project Ideation
+:class: tip
+Communicate with participants on Slack, encouraging project pitching and ideation prior to the hackweek.
+```
+Completion of the helper training will earn you the hackweek helper badge! ![GH](https://img.shields.io/static/v1?label=Hackweek&message=Project_Coordinator&color=4b2e83&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAAOCAQAAABedl5ZAAAACXBIWXMAAAHKAAABygHMtnUxAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAMNJREFUGBltwcEqwwEcAOAfc1F2sNsOTqSlNUopSv5jW1YzHHYY/6YtLa1Jy4mbl3Bz8QIeyKM4fMaUxr4vZnEpjWnmLMSYCysxTcddhF25+EvJia5hhCudULAePyRalvUteXIfBgYxJufRuaKuprKsbDjVUrUj40FNQ11PTzEmrCmrevPhRcVQai8m1PRVvOPZgX2JttWYsGhD3atbHWcyUqX4oqDtJkJiJHUYv+R1JbaNHJmP/+Q1HLu2GbNoSm3Ft0+Y1YMdPSTSwQAAAABJRU5ErkJggg==&style=plastic)
 
 <hr>
 

--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -21,84 +21,98 @@ The eScience Institute supports Community Partners in planning each hackweek. We
 
 <hr>
 
-## Tutorial Lead Meeting Schedule
+## Tutorial Developer Schedule
 
-Tutorial leads and developers typically gather over the course of eight to ten weeks prior to a hackweek to create content and prepare for teaching. Below is an example eight week meeting schedule, which does not include individual or team time spent preparing tutorial content:
+![GH](https://img.shields.io/static/v1?label=Hackweek&message=Tutorial_Lead&color=4b2e83&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAAOCAQAAABedl5ZAAAACXBIWXMAAAHKAAABygHMtnUxAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAMNJREFUGBltwcEqwwEcAOAfc1F2sNsOTqSlNUopSv5jW1YzHHYY/6YtLa1Jy4mbl3Bz8QIeyKM4fMaUxr4vZnEpjWnmLMSYCysxTcddhF25+EvJia5hhCudULAePyRalvUteXIfBgYxJufRuaKuprKsbDjVUrUj40FNQ11PTzEmrCmrevPhRcVQai8m1PRVvOPZgX2JttWYsGhD3atbHWcyUqX4oqDtJkJiJHUYv+R1JbaNHJmP/+Q1HLu2GbNoSm3Ft0+Y1YMdPSTSwQAAAABJRU5ErkJggg==&style=plastic)
 
-```{Admonition} Week 1 / 90 min: Kick-off Meeting (everyone)
+Tutorial leads and developers typically gather over the course of about eight weeks prior to a hackweek to create content and prepare for teaching. Below is an example eight week meeting schedule, which does not include individual or team time spent preparing tutorial content:
+
+```{Admonition} Week -8 (90 min): Kick-off Meeting (everyone)
 Create tutorial schedule outline, form tutorial teams, and get to know each other.
 ```
 
-```{Admonition} Week 2: Video Training (individual)
+```{Admonition} Week -7: Video Training (individual)
 :class: tip
 **Tutorial Development (20 min)**: Best practices, pedagogy, learning outcomes, and scoping a tutorial.
 
 **Technical Infrastructure (20 min)**: Overview of Jupyter Notebooks and pushing content to our Jupyter Book.
 ```
 
-```{Admonition} Week 2 (60 min): Tutorial Outlining Meeting (tutorial teams)
+```{Admonition} Week -7 (60 min): Tutorial Outlining Meeting (tutorial teams)
 Meet with tutorial team to scope and outline tutorial content.
 ```
 
-```{Admonition} Week 3 (60 min): Tutorial Report-Out Meeting (everyone)
+```{Admonition} Week -6 (60 min): Tutorial Report-Out Meeting (everyone)
 Each team shares scope and outline and together we identify overlaps, ways to integrate content and decide on tutorial sequencing.
 ```
 
-```{Admonition} Week 3: Open Office Hours (individual)
+```{Admonition} Week -6: Open Office Hours (individual)
 :class: tip
 Get help with technical infrastructure and practice doing a pull request to the Jupyterbook.
 ```
 
-```{Admonition} Week 4: Video Training (individual)
+```{Admonition} Week -5: Video Training (individual)
 :class: tip
 **Tutorial Development (20 min)**: Learn ways to engage with participants and incorporate peer-learning into your lessons.
 ```
 
-```{Admonition} Week 4 (60 min): Tutorial Development (tutorial teams)
+```{Admonition} Week -5 (60 min): Tutorial Development (tutorial teams)
 Discuss places/ways to engage participants and incorporate interactive components.
 ```
 
-```{Admonition} Week 5: Open Office Hours (individual)
+```{Admonition} Week -4: Open Office Hours (individual)
 :class: tip
 Tutorial development help.
 ```
 
-```{Admonition} Week 6 and 7 (60 min): Tutorial Feedback (everyone)
+```{Admonition} Week -3 and -2 (60 min): Tutorial Feedback (everyone)
 Practice tutorial delivery and get constructive feedback from others on the organizing team.
 ```
 
-```{Admonition} Week 8 (60 min): Final meeting (everyone)
+```{Admonition} Week -1 (60 min): Final meeting (everyone)
 Coordination, logistics, and final preparations.
 ```
 
-Upon completion of this training you will be awarded a tutorial lead badge! ![GH](https://img.shields.io/static/v1?label=Hackweek&message=Tutorial_Lead&color=4b2e83&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAAOCAQAAABedl5ZAAAACXBIWXMAAAHKAAABygHMtnUxAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAMNJREFUGBltwcEqwwEcAOAfc1F2sNsOTqSlNUopSv5jW1YzHHYY/6YtLa1Jy4mbl3Bz8QIeyKM4fMaUxr4vZnEpjWnmLMSYCysxTcddhF25+EvJia5hhCudULAePyRalvUteXIfBgYxJufRuaKuprKsbDjVUrUj40FNQ11PTzEmrCmrevPhRcVQai8m1PRVvOPZgX2JttWYsGhD3atbHWcyUqX4oqDtJkJiJHUYv+R1JbaNHJmP/+Q1HLu2GbNoSm3Ft0+Y1YMdPSTSwQAAAABJRU5ErkJggg==&style=plastic).
+```{Admonition} Hackweek
+One or more of the tutorial developers delivers the content on the specified day. Other developer(s) attend to offer help.
+```
 
 <hr>
 
-## Project Consultant
+## Project Consultant Schedule
+
+![GH](https://img.shields.io/static/v1?label=Hackweek&message=Project_Coordinator&color=4b2e83&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAAOCAQAAABedl5ZAAAACXBIWXMAAAHKAAABygHMtnUxAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAMNJREFUGBltwcEqwwEcAOAfc1F2sNsOTqSlNUopSv5jW1YzHHYY/6YtLa1Jy4mbl3Bz8QIeyKM4fMaUxr4vZnEpjWnmLMSYCysxTcddhF25+EvJia5hhCudULAePyRalvUteXIfBgYxJufRuaKuprKsbDjVUrUj40FNQ11PTzEmrCmrevPhRcVQai8m1PRVvOPZgX2JttWYsGhD3atbHWcyUqX4oqDtJkJiJHUYv+R1JbaNHJmP/+Q1HLu2GbNoSm3Ft0+Y1YMdPSTSwQAAAABJRU5ErkJggg==&style=plastic)
 
 The [Project Consultant](../services/project-consultant.md) has a big-picture view of the possible scope of projects for the hackweek community, and helps participants get clear on project ideas and objectives. Project Consultants are asked to participate in a virtual training session, and to begin assisting participants in advance of the event:
 
-```{Admonition} 60 min: Project Consultant Orientation
+```{Admonition} Week -4 (60 min): Project Consultant Orientation
 Learn our approach for setting up and guiding project work; discuss approaches for fostering project ideas for this specific community.
 ```
 
-```{Admonition} Guiding Project Ideation
+```{Admonition} Week -3 to -1: Guiding Project Ideation
 :class: tip
 Communicate with participants on Slack, encouraging project pitching and ideation prior to the hackweek.
 ```
-Completion of the helper training will earn you the hackweek helper badge! ![GH](https://img.shields.io/static/v1?label=Hackweek&message=Project_Coordinator&color=4b2e83&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAAOCAQAAABedl5ZAAAACXBIWXMAAAHKAAABygHMtnUxAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAMNJREFUGBltwcEqwwEcAOAfc1F2sNsOTqSlNUopSv5jW1YzHHYY/6YtLa1Jy4mbl3Bz8QIeyKM4fMaUxr4vZnEpjWnmLMSYCysxTcddhF25+EvJia5hhCudULAePyRalvUteXIfBgYxJufRuaKuprKsbDjVUrUj40FNQ11PTzEmrCmrevPhRcVQai8m1PRVvOPZgX2JttWYsGhD3atbHWcyUqX4oqDtJkJiJHUYv+R1JbaNHJmP/+Q1HLu2GbNoSm3Ft0+Y1YMdPSTSwQAAAABJRU5ErkJggg==&style=plastic)
+
+```{Admonition} Hackweek
+Attend on day 1 to guide formation of teams and ideally other days of the week to assist as projects continue.
+```
 
 <hr>
 
-## Helper
+## Helper Schedule
+
+![GH](https://img.shields.io/static/v1?label=Hackweek&message=Helper&color=4b2e83&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAAOCAQAAABedl5ZAAAACXBIWXMAAAHKAAABygHMtnUxAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAMNJREFUGBltwcEqwwEcAOAfc1F2sNsOTqSlNUopSv5jW1YzHHYY/6YtLa1Jy4mbl3Bz8QIeyKM4fMaUxr4vZnEpjWnmLMSYCysxTcddhF25+EvJia5hhCudULAePyRalvUteXIfBgYxJufRuaKuprKsbDjVUrUj40FNQ11PTzEmrCmrevPhRcVQai8m1PRVvOPZgX2JttWYsGhD3atbHWcyUqX4oqDtJkJiJHUYv+R1JbaNHJmP/+Q1HLu2GbNoSm3Ft0+Y1YMdPSTSwQAAAABJRU5ErkJggg==&style=plastic)
 
 Helpers are critical to keeping a hackweek running smoothly and sharing information among participants and organizers. Helpers are asked to attend a virtual training session shortly before the hackweek:
 
-```{Admonition} 90 min: Helper Orientation
+```{Admonition} Week -1 (90 min): Helper Orientation
 Learn best practices for giving help to learners in a virtual and in-person environment; discuss schedule and helper opportunities; sign up for specific times.
 ```
-Completion of the helper training will earn you the hackweek helper badge! ![GH](https://img.shields.io/static/v1?label=Hackweek&message=Helper&color=4b2e83&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAAOCAQAAABedl5ZAAAACXBIWXMAAAHKAAABygHMtnUxAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAMNJREFUGBltwcEqwwEcAOAfc1F2sNsOTqSlNUopSv5jW1YzHHYY/6YtLa1Jy4mbl3Bz8QIeyKM4fMaUxr4vZnEpjWnmLMSYCysxTcddhF25+EvJia5hhCudULAePyRalvUteXIfBgYxJufRuaKuprKsbDjVUrUj40FNQ11PTzEmrCmrevPhRcVQai8m1PRVvOPZgX2JttWYsGhD3atbHWcyUqX4oqDtJkJiJHUYv+R1JbaNHJmP/+Q1HLu2GbNoSm3Ft0+Y1YMdPSTSwQAAAABJRU5ErkJggg==&style=plastic).
+
+```{Admonition} Hackweek
+Attend the tutorial(s) or project(s) for which you'd like to offer help.
+```
 
 <hr>
 

--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -19,6 +19,8 @@ The eScience Institute supports Community Partners in planning each hackweek. We
 
 ::::
 
+<hr>
+
 ## Tutorial Lead Meeting Schedule
 
 Tutorial leads and developers typically gather over the course of eight to ten weeks prior to a hackweek to create content and prepare for teaching. Below is an example eight week meeting schedule, which does not include individual or team time spent preparing tutorial content:
@@ -62,7 +64,7 @@ Tutorial development help.
 ```
 
 ```{Admonition} Week 6 and 7 (60 min): Tutorial Feedback (everyone)
-Practice tutorial delivery and get constructive feedback from others on the team.
+Practice tutorial delivery and get constructive feedback from others on the organizing team.
 ```
 
 ```{Admonition} Week 8 (60 min): Final meeting (everyone)
@@ -71,15 +73,22 @@ Coordination, logistics, and final preparations.
 
 Upon completion of this training you will be awarded a tutorial lead badge! ![GH](https://img.shields.io/static/v1?label=Hackweek&message=Tutorial_Lead&color=4b2e83&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAAOCAQAAABedl5ZAAAACXBIWXMAAAHKAAABygHMtnUxAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAMNJREFUGBltwcEqwwEcAOAfc1F2sNsOTqSlNUopSv5jW1YzHHYY/6YtLa1Jy4mbl3Bz8QIeyKM4fMaUxr4vZnEpjWnmLMSYCysxTcddhF25+EvJia5hhCudULAePyRalvUteXIfBgYxJufRuaKuprKsbDjVUrUj40FNQ11PTzEmrCmrevPhRcVQai8m1PRVvOPZgX2JttWYsGhD3atbHWcyUqX4oqDtJkJiJHUYv+R1JbaNHJmP/+Q1HLu2GbNoSm3Ft0+Y1YMdPSTSwQAAAABJRU5ErkJggg==&style=plastic).
 
-
-
+<hr>
 
 ## Project Coordinator
 
-## Helper Schedule
+<hr>
 
-Helpers are critical to keeping a hackweek running smoothly and sharing information among participants and organizers. Helpers are asked to attend a virtual training session (60 minutes), usually the week before the hackweek, to get an overview of the event, have an opportunity to ask questions, and commit to being a helper for a specific day.
+## Helper
 
+Helpers are critical to keeping a hackweek running smoothly and sharing information among participants and organizers. Helpers are asked to attend a virtual training session shortly before the hackweek:
+
+```{Admonition} 90 min: Helper Orientation
+Learn best practices for giving help to learners in a virtual and in-person environment; discuss schedule and helper opportunities; sign up for specific times.
+```
+Completion of the helper training will earn you the hackweek helper badge! ![GH](https://img.shields.io/static/v1?label=Hackweek&message=Helper&color=4b2e83&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAAOCAQAAABedl5ZAAAACXBIWXMAAAHKAAABygHMtnUxAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAMNJREFUGBltwcEqwwEcAOAfc1F2sNsOTqSlNUopSv5jW1YzHHYY/6YtLa1Jy4mbl3Bz8QIeyKM4fMaUxr4vZnEpjWnmLMSYCysxTcddhF25+EvJia5hhCudULAePyRalvUteXIfBgYxJufRuaKuprKsbDjVUrUj40FNQ11PTzEmrCmrevPhRcVQai8m1PRVvOPZgX2JttWYsGhD3atbHWcyUqX4oqDtJkJiJHUYv+R1JbaNHJmP/+Q1HLu2GbNoSm3Ft0+Y1YMdPSTSwQAAAABJRU5ErkJggg==&style=plastic).
+
+<hr>
 
 ## Funding Support    
 

--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -1,25 +1,83 @@
 # Resources for Organizers
 
-The eScience Institute supports Community Partners in planning each hackweek. We invite organizers to join a series of planning sessions to prepare for an event. Not everyone is expected to attend every session, and your level of commitment will depend on your chosen role.
+The eScience Institute supports Community Partners in planning each hackweek. We invite organizers to participate in video and live training sessions tailored to each of the Community Partner roles. Upon completion of the training, organizer profiles will be posted on the hackweek website along with badge(s) representing their roles in the event. 
 
-## Planning Sessions
+::::{grid}
+:gutter: 1
 
-We host a series of 8 to 10 weekly planning sessions on zoom during the two months prior to a hackweek. These sessions include:
+:::{grid-item-card} [Tutorial Lead](#tutorial-lead)
+[![GH](https://img.shields.io/static/v1?label=eScience&message=Tutorial-Lead&color=b7a57a)](#tutorial-lead)
+:::
 
-* a kickoff meeting to build team connections and to get clear on the purpose of the hackweek
-* scheduling and logistics planning 
-* tutorial ideation and design 
-* website creation and publishing of Jupyter Notebooks
-* designing structures to support project team work
+:::{grid-item-card} [Project Coordinator](#project-coordinator)
+[![GH](https://img.shields.io/static/v1?label=eScience&message=Project-Coordinator&color=85754d)](#project-coordinator)
+:::
 
-## Professional Development Opportunities
+:::{grid-item-card} [Helper](#helper)
+[![GH](https://img.shields.io/static/v1?label=eScience&message=Helper&color=4b2e83)](#helper)
+:::
 
-We recognize that many people will be new to tutorial design and guiding project work. Therefore we offer several opportunities for professional development for hackweek organizing teams. These include training sessions in:
+::::
 
-* data science pedagogy
-* facilitation approaches to foster teamwork and collaboration
-* peer feedback on tutorial delivery
-* best practices for creating inclusive and welcoming event spaces
+## Tutorial Lead Meeting Schedule
+
+Tutorial leads and developers will gather two months prior to a hackweek to create content and prepare for teaching. Here is the weekly schedule:
+
+```{Admonition} Week 1 / 90 min: Kick-off Meeting (everyone)
+Create tutorial schedule outline, form tutorial teams, and get to know each other.
+```
+
+```{Admonition} Week 2: Video Training (individual)
+:class: tip
+**Tutorial Development (20 min)**: Best practices, pedagogy, learning outcomes, and scoping a tutorial.
+
+**Technical Infrastructure (20 min)**: Overview of Jupyter Notebooks and pushing content to our Jupyter Book.
+```
+
+```{Admonition} Week 2 (60 min): Tutorial Outlining Meeting (tutorial teams)
+Meet with tutorial team to scope and outline tutorial content.
+```
+
+```{Admonition} Week 3 (60 min): Tutorial Report-Out Meeting (everyone)
+Each team shares scope and outline and together we identify overlaps, ways to integrate content and decide on tutorial sequencing.
+```
+
+```{Admonition} Week 3: Open Office Hours (individual)
+:class: tip
+Get help with technical infrastructure and practice doing a pull request to the Jupyterbook.
+```
+
+```{Admonition} Week 4: Video Training (individual)
+:class: tip
+**Tutorial Development (20 min)**: Learn ways to engage with participants and incorporate peer-learning into your lessons.
+```
+
+```{Admonition} Week 4 (60 min): Tutorial Development (tutorial teams)
+Discuss places/ways to engage participants and incorporate interactive components.
+```
+
+```{Admonition} Week 5: Open Office Hours (individual)
+:class: tip
+Tutorial development help.
+```
+
+```{Admonition} Week 6 and 7 (60 min): Tutorial Feedback (everyone)
+Practice tutorial delivery and get constructive feedback from others on the team.
+```
+
+```{Admonition} Week 8 (60 min): Final meeting (everyone)
+Coordination, logistics, and final preparations.
+```
+
+Upon completion of this training you will be awarded a tutorial lead badge! ![GH](https://img.shields.io/static/v1?label=eScience&message=Tutorial-Lead&color=b7a57a).
+
+
+
+
+## Project Coordinator
+
+# Helper
+
 
 ## Funding Support    
 

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -212,6 +212,8 @@ Our clients who partner with us to host a hackweek are responsible for creating 
 
 ::::
 
+Visit our [Resources for Organizers](../resources/index.md) page to learn more about the training and preparation we offer to community members for many of these roles.
+
 ## Time Commitment
 
 There is considerable variability in the amount of time people spend on various hackweek roles. The level of effort depends on event size, whether it has been run before, and the number of other people available. 


### PR DESCRIPTION
This PR adds a schedule of organizing team (OT) activities to prepare for the hackweek. It also brings back the concept of badges that people earn for passing through each training. There would be similar (shorter) schedules for project coordination and helpers.

I'm not sure about using admonitions for each week. Wanted to find a way to color code based on individual/asynchronous work versus team meetings. I'd welcome ideas.