### PR TITLE
Conda - Unpin the Jupyter Book version

### DIFF
--- a/.github/actions/setupconda/action.yml
+++ b/.github/actions/setupconda/action.yml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Cache Conda Packages
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       env:
         # Increase this value to reset cache if environment.yml has not changed
         CACHE_NUMBER: 0
@@ -15,7 +15,7 @@ runs:
           ${{ runner.os }}-conda-packages-${{ env.CACHE_NUMBER }}-${{ hashFiles('environment.yml') }}
 
     - name: Setup Mambaforge
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v3
       with:
         miniforge-version: latest
         miniforge-variant: Mambaforge
@@ -26,7 +26,7 @@ runs:
 
     - name: Cache Entire Conda Environment
       id: cache-env
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       env:
         CACHE_NUMBER: 0
       with:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -11,13 +11,13 @@ on:
 
 jobs:
   build-and-deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash -l {0}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: ./.github/actions/setupconda
 

--- a/.github/workflows/netlifypreview.yaml
+++ b/.github/workflows/netlifypreview.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   add-preview:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     # This workflow accesses secrets and checks out a PR, so only run if labelled
     # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
     if: contains(github.event.pull_request.labels.*.name, 'preview')
@@ -20,7 +20,7 @@ jobs:
         shell: bash -l {0}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
 
@@ -31,7 +31,7 @@ jobs:
         jupyter-book build docs/
 
     - name: Deploy Website Preview
-      uses: nwtgck/actions-netlify@v1.1
+      uses: nwtgck/actions-netlify@v3.0
       with:
         publish-dir: './docs/_build/html'
         production-deploy: false

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,13 +11,13 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash -l {0}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: ./.github/actions/setupconda
 

--- a/environment.yml
+++ b/environment.yml
@@ -2,5 +2,4 @@ name: hackweek-guidebook
 channels:
   - conda-forge
 dependencies:
-  - python=3.10
-  - jupyter-book=0.13
+  - jupyter-book


### PR DESCRIPTION
We recently updated the website template and I can not think of a reason why this guidebook shouldn't do the same.